### PR TITLE
docs: SBOM requirements + sbomqs lessons learned

### DIFF
--- a/workspace/knowledge/compliance.md
+++ b/workspace/knowledge/compliance.md
@@ -31,9 +31,57 @@ If changing a project's license:
 4. Verify dependency compatibility with new license (`cargo deny`)
 5. Note the change in CHANGELOG
 
+## SBOM Requirements (Rust)
+
+### Minimum requirements
+
+Generate an SBOM for **release** and **nightly** builds:
+
+- Tool: `cargo-cyclonedx`
+- Format: CycloneDX **JSON + XML**
+- Spec version: prefer **CycloneDX 1.5+**
+- Artifact: package SBOMs as build artifacts (and attach to GitHub Release for tagged builds)
+
+### Quality gate (sbomqs)
+
+Add an SBOM quality gate using [`sbomqs`](https://github.com/interlynk-io/sbomqs):
+
+- Run `sbomqs score` on the generated SBOM JSON files
+- Fail the workflow if any SBOM score is below the threshold
+- Suggested thresholds:
+  - **Initial**: ≥ **7.0** (avoid blocking early adoption)
+  - **Target**: ≥ **8.5** once metadata is improved
+  - **Stretch**: ≥ **9.0** after signing + additional identifiers
+
+### Required metadata improvements (lessons learned)
+
+`cargo-cyclonedx` produces a strong Cargo-native dependency graph (licenses, checksums, source URIs), but SBOM quality scoring often flags missing *document* metadata fields.
+
+To raise SBOM quality, add a deterministic post-processing step for `*.cdx.json` SBOMs that injects:
+
+- SBOM data license (e.g., **CC0-1.0**) in `metadata.licenses`
+- Build lifecycle phase (e.g., `metadata.lifecycles: [{ phase: "build" }]`)
+- Supplier names:
+  - first-party workspace crates → supplier = repo owner/org
+  - crates.io dependencies → supplier = `crates.io` (best-effort)
+
+### Common pitfalls
+
+- **Fixture pollution**: if you store SBOM fixtures for tests, ensure your SBOM collection step excludes them (e.g., exclude `*/fixtures/*`). Otherwise the quality gate will score the fixture and fail.
+- **Shell quoting**: when generating PR bodies / issue comments via CLI, avoid unescaped backticks (`` ` ``) inside double-quoted strings; use `--body-file` to prevent shell command substitution.
+
+### Optional (for 9.0+)
+
+To push scores toward 9.0+:
+
+- Add additional vulnerability lookup identifiers (e.g., CPE) alongside purl
+- Add SBOM signing (cosign/sigstore) and publish signatures
+- Add BOM links / external references where meaningful
+
 ## CI Integration
 
 Add compliance checks to CI:
 - SPDX header verification (grep/script)
 - `cargo deny` or equivalent dependency audit
 - SBOM generation on release builds
+- SBOM quality gate on release/nightly builds

--- a/workspace/knowledge/patterns.md
+++ b/workspace/knowledge/patterns.md
@@ -31,6 +31,16 @@ The most reliable Codex output comes from single-file task specs with explicit v
 
 **Anti-pattern:** Giving Codex broad instructions without a written spec leads to scope creep and inconsistent results.
 
+## SBOM Quality Gating (Lessons Learned)
+
+When adding SBOMs to release/nightly workflows:
+
+- Prefer **cargo-native SBOM generation** (`cargo-cyclonedx`) for accurate dependency graphs.
+- Add a **post-processing step** for CycloneDX JSON to inject missing document metadata (CC0 license, build lifecycle, supplier hints).
+- Add a **quality gate** (`sbomqs score`) with a conservative initial threshold (≥7.0), then ratchet upward.
+- Ensure SBOM collection excludes test fixtures (`*/fixtures/*`) so the gate doesn't fail on minimal stub SBOMs.
+- Upload the scoring output (e.g., `sbomqs-results.json`) as an artifact for debugging regressions.
+
 ## Pre-Commit Validation
 
 Always run the full validation chain before declaring implementation complete:


### PR DESCRIPTION
Adds a concrete SBOM policy + lessons learned from rust-gvm:

- SBOM generation requirements for Rust (cargo-cyclonedx, CycloneDX JSON+XML, prefer 1.5+)
- sbomqs quality gate guidance (threshold ratcheting 7.0 → 8.5 → 9.0)
- deterministic post-processing recommendations (CC0 doc license, build lifecycle, supplier hints)
- pitfalls observed in practice:
  - SBOM fixture files accidentally included in collection/scoring
  - shell backtick expansion when writing GH issue/PR bodies (use --body-file)

Files:
- workspace/knowledge/compliance.md
- workspace/knowledge/patterns.md
