### PR TITLE
ci: add auto-merge (squash) workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto-merge squash
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash) for non-draft PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `auto-merge.yml` workflow that automatically enables squash auto-merge on all non-draft PRs.

Based on [greenbone/pontos auto-merge pattern](https://github.com/greenbone/pontos/blob/main/.github/workflows/auto-merge.yml).