### PR TITLE
docs: add communication rules — always include GitHub links and repo paths

### DIFF
--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -18,3 +18,8 @@ the supervisor and the human.
 - **ALWAYS include clickable GitHub links** when referencing PRs, issues, or repositories (e.g. `[clawosiris/rust-gvm#37](https://github.com/clawosiris/rust-gvm/pull/37)`, not just `#37`)
 - **ALWAYS include the full repo path** in output (e.g. `clawosiris/rust-gvm#37`, not just `#37`) — especially in cron job and monitoring output
 - Never reference a PR/issue number without a link
+
+## CI Rules
+
+- **Always try to fix failing CI checks in PRs on your own** — push real fixes to the PR branch. No `continue-on-error`, no skipping, no ignoring errors.
+- Only communicate a CI failure to the team if you've tried to fix it and couldn't. Include what you tried and what the remaining error is.


### PR DESCRIPTION
Formalizes communication rules in SOUL.md that were repeatedly requested by the team:

- **Always include clickable GitHub links** when referencing PRs, issues, or repos
- **Always include the full repo path** (e.g. `clawosiris/rust-gvm#37`, not just `#37`)
- **Never reference a PR/issue without a link**

These rules should apply to all agents using the forge workspace, including cron job output and monitoring reports.